### PR TITLE
Fixing check_invalid_config tool issues and optimizing nspepi tool conversion

### DIFF
--- a/nspepi/README.md
+++ b/nspepi/README.md
@@ -31,6 +31,16 @@ For using the conversion tools, copy the files from here to your Citrix ADC appl
 3. Copy all files under the `nspepi2` directory to the `/netscaler/nspepi2` path in Citrix ADC.
 4. After copying files to Citrix ADC, change your directory to `/netscaler` and then run the `bash nspepi_install_script` command.
 
+### NSPEPI and check_invalid_config tools can be run on the CentOS and Ubuntu systems
+
+The following modules are the prerequisites for using these tools:
+
+- Python
+- Perl
+- Python pip module
+- Ply module for Python
+- Switch.pm for Perl
+
 ## Pre-validation tool for removed or deprecated features in Citrix ADC version 13.1
 
 This is a pre-validation tool to check if any deprecated functionality that is removed from Citrix ADC 13.1 is still used in the configuration for your current release. If the validation result shows usage of a deprecated functionality, then before upgrading your appliance, you must first modify the configuration to the Citrix recommended alternative. You can modify the configuration either manually or using the NSPEPI tool.

--- a/nspepi/check_invalid_config
+++ b/nspepi/check_invalid_config
@@ -40,7 +40,8 @@ if (not -e $config_file) {
 
 my($filename, $dir_path) = fileparse($config_file);
 
-my $exit_status = system("python /netscaler/nspepi2/config_check_main.py -f $config_file");
+my $dirname = dirname(__FILE__);
+my $exit_status = system("python $dirname/nspepi2/config_check_main.py -f $config_file");
 if ($exit_status != 0) {
 	print "Error in checking config file: $exit_status";
 	exit;

--- a/nspepi/nspepi2/config_check_main.py
+++ b/nspepi/nspepi2/config_check_main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021 Citrix Systems, Inc.  All rights reserved.
+# Copyright 2021-2023 Citrix Systems, Inc.  All rights reserved.
 # Use of this software is governed by the license terms, if any,
 # which accompany or are included with this software.
 
@@ -89,56 +89,6 @@ def output_line(line, outfile, verbose):
         logging.info(line.rstrip())
 
 
-def check_for_removed_expression(cmd, outfile, verbose):
-    """
-    Checks for the expressions which are removed.
-    Args:
-	cmd: NS config command to be checked
-        outfile: Output file to write commands using removed config
-        verbose: True iff converted commands should also be output to console
-    """
-    if re.search(r'\bSYS\s*\.\s*EVAL_CLASSIC_EXPR\s*\(',
-                 cmd, re.IGNORECASE):
-        output_line(cmd, outfile, verbose)
-        return
-
-    body_expr = re.compile(r'\bHTTP\s*\.\s*REQ\s*\.\s*BODY\b\s*', re.IGNORECASE)
-    cmd_len = len(cmd)
-    for match in re.finditer(body_expr, cmd):
-        start_index = match.start()
-        length = match.end() - match.start()
-        if (((start_index + length) >= cmd_len) or
-             (cmd[start_index + length] != '(')):
-            output_line(cmd, outfile, verbose)
-            return
-
-    if re.search(r'\b((Q\.HOSTNAME)|(Q\.TRACKING)|'
-                 '(Q\.METHOD)|(Q\.URL)|(Q\.VERSION)|'
-                 '(Q\.CONTENT_LENGTH)|(Q\.HEADER)|'
-                 '(Q\.IS_VALID)|(Q\.DATE)|'
-                 '(Q\.COOKIE)|(Q\.BODY)|(Q\.TXID)|'
-                 '(Q\.CACHE_CONTROL)|(Q\.USER)|'
-                 '(Q\.IS_NTLM_OR_NEGOTIATE)|'
-                 '(Q\.FULL_HEADER)|'
-                 '(Q\.LB_VSERVER)|(Q\.CS_VSERVER))',
-                 cmd, re.IGNORECASE):
-        output_line(cmd, outfile, verbose)
-        return
-
-    if re.search(r'\b((S\.VERSION)|(S\.STATUS)|'
-                  '(S\.STATUS_MSG)|(S\.IS_REDIRECT)|'
-                  '(S\.IS_INFORMATIONAL)|(S\.IS_SUCCESSFUL)|'
-                  '(S\.IS_CLIENT_ERROR)|(S\.IS_SERVER_ERROR)|'
-                  '(S\.TRACKING)|(S\.HEADER)|(S\.FULL_HEADER)|'
-                  '(S\.IS_VALID)|(S\.DATE)|(S\.BODY)|'
-                  '(S\.SET_COOKIE)|(S\.SET_COOKIE2)|'
-                  '(S\.CONTENT_LENGTH)|'
-                  '(S\.CACHE_CONTROL)|(S\.TXID)|(S\.MEDIA))',
-		  cmd, re.IGNORECASE):
-        output_line(cmd, outfile, verbose)
-        return
-
-
 def check_config_file(infile, outfile, verbose):
     """
     Process ns config file passed in argument and report the classic and
@@ -174,14 +124,9 @@ def check_config_file(infile, outfile, verbose):
                     # converting to advanced, so list will contains
                     # at most only one command.
                     output = m.method(m.obj, parsed_tree)
-                    if len(output) == 0:
-                        check_for_removed_expression(cmd, outfile, verbose)
-                    else:
+                    if len(output) != 0:
                          output_line(cmd, outfile, verbose)
-            else:
-                check_for_removed_expression(cmd, outfile, verbose)
-        else:
-            check_for_removed_expression(cmd, outfile, verbose)
+
 
 
 def main():

--- a/nspepi/nspepi2/convert_cmp_cmd.py
+++ b/nspepi/nspepi2/convert_cmp_cmd.py
@@ -235,6 +235,7 @@ class CMP(cli_cmds.ConvertConfig):
         If bound policy is classic built-in policy, then replace policy name
         with advanced built-in policy.
         """
+        policy_name = policy_name.lower()
         if policy_name in self.built_in_policies:
             # Update policy name to advanced policy name.
             self.update_tree_arg(bind_cmd_tree, policy_arg,

--- a/nspepi/nspepi2/convert_filter_command.py
+++ b/nspepi/nspepi2/convert_filter_command.py
@@ -638,6 +638,7 @@ class CLITransformFilter(cli_cmds.ConvertConfig):
            action_tree - stored action command at respective index in
                  _action_command
         """
+        cli_cmds.filter_policy_exists = True
         original_cmd = copy.deepcopy(policy_parse_tree)
         policyName = policy_parse_tree.positional_value(0).value
         pol_obj = common.Policy(policyName, self.__class__.__name__, "classic")

--- a/nspepi/nspepi2/convert_responder_command.py
+++ b/nspepi/nspepi2/convert_responder_command.py
@@ -77,6 +77,11 @@ class Responder(cli_cmds.ConvertConfig):
               HTTP/SSL vservers
         tree - bind command parse tree
         """
+        # If no filter policy is configured, then no need to process
+        # responder bindings
+        if not cli_cmds.filter_policy_exists:
+            return [tree]
+
         get_goto_arg = tree.positional_value(2).value
         policy_name = tree.positional_value(0).value
         get_bind_type = tree.keyword_value("type")[0].value
@@ -107,6 +112,11 @@ class Responder(cli_cmds.ConvertConfig):
         When responder policy is bound:
         1. Check if GOTO is END/USE_INVOCATION_RESULT for HTTP/SSL vservers
         """
+        # If no filter policy is configured, then no need to process
+        # responder bindings
+        if not cli_cmds.filter_policy_exists:
+            return [bind_parse_tree]
+
         get_goto_arg = bind_parse_tree.keyword_value(
             "gotoPriorityExpression")[0].value
         policy_name = bind_parse_tree.keyword_value("policyName")[0].value

--- a/nspepi/nspepi2/convert_rewrite_command.py
+++ b/nspepi/nspepi2/convert_rewrite_command.py
@@ -63,7 +63,7 @@ class Rewrite(cli_cmds.ConvertConfig):
             tree.add_keyword(search_val_param)
         if tree.keyword_exists('bypassSafetyCheck'):
             tree.remove_keyword('bypassSafetyCheck')
-        tree = Rewrite.convert_adv_expr_list(tree, [3, "refineSearch"])
+        tree = Rewrite.convert_adv_expr_list(tree, [2, 3, "refineSearch"])
         return [tree]
 
     @common.register_for_cmd("add", "rewrite", "policy")
@@ -89,6 +89,11 @@ class Rewrite(cli_cmds.ConvertConfig):
             HTTP/SSL vservers
         tree - bind command parse tree
         """
+        # If no filter policy is configured, then no need to process
+        # rewrite bindings
+        if not cli_cmds.filter_policy_exists:
+            return [tree]
+
         get_goto_arg = tree.positional_value(2).value
         policy_name = tree.positional_value(0).value
         get_bind_type = tree.keyword_value("type")[0].value
@@ -124,6 +129,11 @@ class Rewrite(cli_cmds.ConvertConfig):
         2. vserver_protocol_dict - dict from cli_cmds and convert_lb_cmd
               packages which carries protocol as value to the key - vserver name
         """
+        # If no filter policy is configured, then no need to process
+        # rewrite bindings
+        if not cli_cmds.filter_policy_exists:
+            return [bind_parse_tree]
+
         get_goto_arg = bind_parse_tree.keyword_value(
             "gotoPriorityExpression")[0].value
         vs_name = bind_parse_tree.positional_value(0).value.lower()


### PR DESCRIPTION
Fixes:
1. Don't process Content Switch, Rewrite, and Responder policies bindings if classic CS policies or Filter policies are not present
2. Fixing the issues occurs in running check_invalid_config tool on Linux box