### PR TITLE
CS policy name changed even when bound to one CS vserver, Handling default CMP bindings

### DIFF
--- a/nspepi/check_invalid_config
+++ b/nspepi/check_invalid_config
@@ -27,7 +27,7 @@ if (!($python_module_list =~ m/\bply==/)) {
 
 
 my $number_args = $#ARGV + 1;
-if ($number_args > 3) {
+if ($number_args > 3 or $number_args < 1) {
     tool_usage();
     exit;
 }
@@ -74,10 +74,10 @@ my $deprecated_config_file = $dir_path."deprecated_".$filename;
 
 # Checks whether any command is present in the file
 if (!(-z $invalid_config_file)) {
-    print "\nThe following configuration lines will get errors in ".$buildVersion." and both they and dependent configuration will be removed from the configuration:\n";
-    system("cat $invalid_config_file");
-    print "\nThe nspepi upgrade tool can be useful in converting your configuration - see the documentation at https://docs.citrix.com/en-us/citrix-adc/current-release/appexpert/policies-and-expressions/introduction-to-policies-and-exp/converting-policy-expressions-nspepi-tool.html.\n";
-    print "\nNOTE: the nspepi tool doesn't convert the following configurations:\n\t1. SureConnect commands\n\t2. PriorityQueuing commands\n\t3. HTTP Denial of Service Protection commands\n\t4. Classic SSL commands\n\t5. HTMLInjection commands.\n";
+	print "\nThe following configuration lines will get errors in ".$buildVersion." and both they and dependent configuration will be removed from the configuration:\n";
+	system("cat $invalid_config_file");
+	print "\nThe nspepi upgrade tool can be useful in converting your configuration - see the documentation at https://docs.citrix.com/en-us/citrix-adc/current-release/appexpert/policies-and-expressions/introduction-to-policies-and-exp/converting-policy-expressions-nspepi-tool.html.\n";
+	print "\nNOTE: the nspepi tool doesn't convert the following configurations:\n\t1. SureConnect commands\n\t2. PriorityQueuing commands\n\t3. HTTP Denial of Service Protection commands\n\t4. Classic SSL commands\n\t5. HTMLInjection commands.\n";
     if (!(-z $deprecated_config_file)) {
         print "\nNOTE: some deprecated commands have also been detected in the config file, please check ".$deprecated_config_file." file for the deprecated commands.\n";
     } else {

--- a/nspepi/nspepi2/check_classic_configs.py
+++ b/nspepi/nspepi2/check_classic_configs.py
@@ -980,7 +980,7 @@ class Deprecation(CheckConfig):
         """
         if commandParseTree.keyword_exists('ssotype'):
             sso_type = commandParseTree.keyword_value("ssotype")[0].value.lower()
-            if sso_type is "selfauth":
+            if sso_type == "selfauth":
                 logging.warning("Selfauth type has been deprecated"
                     " in command [{}]".format(str(commandParseTree).strip()))
         return []
@@ -993,8 +993,8 @@ class Deprecation(CheckConfig):
         """
         if commandParseTree.keyword_exists('basetheme'):
             base_theme = commandParseTree.keyword_value("basetheme")[0].value
-            if base_theme is "Default" or base_theme is "X1" \
-                or base_theme is "Greenbubble":
+            if base_theme == "Default" or base_theme == "X1" \
+                or base_theme == "Greenbubble":
                     logging.warning(("Default, GreenBubble and X1 themes"
                         " have been deprecated in command [{}],"
                         " please use RfWebUI theme or RfWebUI based custom theme")
@@ -1010,8 +1010,8 @@ class Deprecation(CheckConfig):
         """
         if commandParseTree.keyword_exists('portaltheme'):
             base_theme = commandParseTree.keyword_value("portaltheme")[0].value
-            if base_theme is "Default" or base_theme is "X1" \
-                or base_theme is "Greenbubble":
+            if base_theme == "Default" or base_theme == "X1" \
+                or base_theme == "Greenbubble":
                     logging.warning(("Default, GreenBubble and X1 themes"
                         " have been deprecated in command [{}],"
                         " please use RfWebUI theme or RfWebUI based custom theme")
@@ -1025,12 +1025,12 @@ class Deprecation(CheckConfig):
         deprecated.
         """
         action_type = commandParseTree.positional_value(1).value.lower()
-        if action_type is "rewrite_response":
+        if action_type == "rewrite_response":
             logging.warning(("Rewrite_Response action type is deprecated in"
                 " command [{}], please use the replace_dns_answer_section"
                 " action type under Rewrite feature.")
                 .format(str(commandParseTree).strip()))
-        elif action_type is "drop":
+        elif action_type == "drop":
             logging.warning(("Drop action type is deprecated in"
                 " command [{}], please use the Drop"
                 " action type under Responder feature.")
@@ -1090,6 +1090,7 @@ class Deprecation(CheckConfig):
     @common.register_for_cmd("bind", "lsn", "client")
     @common.register_for_cmd("bind", "lsn", "group")
     @common.register_for_cmd("bind", "lsn", "pool")
+    @common.register_for_cmd("set", "lsn", "parameter")
     def check_lsn_commands(self, commandParseTree):
         """
         Check the Authentication commands which have been deprecated

--- a/nspepi/nspepi2/convert_classic_expr.py
+++ b/nspepi/nspepi2/convert_classic_expr.py
@@ -37,7 +37,7 @@ q_s_expr = re.compile(r'\b((Q\.HOSTNAME)|(Q\.TRACKING)|'
                     r'(S\.CACHE_CONTROL)|(S\.TXID)|(S\.MEDIA))\b',
                     re.IGNORECASE)
 
-def convert_classic_expr(classic_expr):
+def convert_classic_expr(classic_expr, ignore_csec_expr = False):
     tree_obj = CLIParseTreeNode()
     info_msg = 'INFO: Expression is not converted' + \
         ' - most likely it is a valid advanced expression'
@@ -62,8 +62,14 @@ def convert_classic_expr(classic_expr):
     if nspepi_tool_output.startswith('ERROR:'):
         """Handles the error returned by old
         nspepi tool"""
-        logging.error(nspepi_tool_output)
-        return None
+        csec_error_msg = 'Conversion of client ' + \
+            'security expression is not supported'
+        if (ignore_csec_expr and (csec_error_msg in \
+                                  nspepi_tool_output)):
+            return "Ignoring Client security Expression"
+        else:
+            logging.error(nspepi_tool_output)
+            return None
     elif nspepi_tool_output.endswith(info_msg):
         """old nspepi tool didn't convert the expression,
         so return input expression"""

--- a/nspepi/nspepi2/convert_cmp_cmd.py
+++ b/nspepi/nspepi2/convert_cmp_cmd.py
@@ -33,6 +33,14 @@ class CMP(cli_cmds.ConvertConfig):
         "ns_nocmp_xml_ie": "ns_adv_nocmp_xml_ie"
     }
 
+    builtin_adv_policies_bind_info = {
+        "ns_adv_nocmp_xml_ie": ["8700", "END"],
+        "ns_adv_nocmp_mozilla_47": ["8800", "END"],
+        "ns_adv_cmp_mscss": ["8900", "END"],
+        "ns_adv_cmp_msapp": ["9000", "END"],
+        "ns_adv_cmp_content_type": ["10000", "END"],
+    }
+
     def __init__(self):
         """
         Information about CMP commands.
@@ -206,6 +214,16 @@ class CMP(cli_cmds.ConvertConfig):
             return ["#" + str(bind_cmd_tree)]
 
         policy_name = bind_cmd_tree.positional_value(0).value
+        # Ignore the default advanced bindings
+        if policy_name in self.builtin_adv_policies_bind_info:
+            policy_info = self.builtin_adv_policies_bind_info[policy_name]
+            priority = bind_cmd_tree.keyword_value("priority")[0].value
+            next_prio_expr = bind_cmd_tree.keyword_value(
+                                    "gotoPriorityExpression")[0].value
+            if ((policy_info[0] == priority) and
+                (policy_info[1] == next_prio_expr)):
+                    return [bind_cmd_tree]
+
         self.replace_builtin_policy(bind_cmd_tree, policy_name, 0)
         bind_point = ""
         self.update_bind_info(bind_cmd_tree, bind_point)

--- a/nspepi/nspepi2/nspepi_helper
+++ b/nspepi/nspepi2/nspepi_helper
@@ -158,11 +158,11 @@ my %EXPR_LIST=(
 
 # List of classic expressions that are not convertable
 my @CSEC_BLOCKED_LIST=(
-    'CLIENT.APPLICATION',
-    'CLIENT.FILE',
-    'CLIENT.OS',
-    'CLIENT.REG',
-    'CLIENT.SVC',
+    'CLIENT\.APPLICATION',
+    'CLIENT\.FILE',
+    'CLIENT\.OS',
+    'CLIENT\.REG',
+    'CLIENT\.SVC',
     'f_5_TrendMicroOfficeScan_7_3',
     'f_5_sygate_5_6',
     'f_5_zonealarm_6_5',
@@ -180,15 +180,15 @@ my @CSEC_BLOCKED_LIST=(
 );
 
 my @FILE_BLOCKED_LIST=(
-    'FS.COMMAND',
-    'FS.DIR',
-    'FS.DOMAIN',
-    'FS.FILE',
-    'FS.PATH',
-    'FS.SERVER',
-    'FS.SERVERIP',
-    'FS.SERVICE',
-    'FS.USER',
+    'FS\.COMMAND',
+    'FS\.DIR',
+    'FS\.DOMAIN',
+    'FS\.FILE',
+    'FS\.PATH',
+    'FS\.SERVER',
+    'FS\.SERVERIP',
+    'FS\.SERVICE',
+    'FS\.USER',
 );
 
 my @BLOCKED_LIST=(
@@ -305,7 +305,7 @@ sub convertExpression
     }
     # Check for client security expression expressions
     foreach (@CSEC_BLOCKED_LIST) {
-        if ($expression  =~ /$_/i) {
+        if ($expression  =~ /\b$_/i) {
             print_it($LFILE,"$line\n");
             err_handle $ERR_CSEC_BLOCKED_MSG;
             return;
@@ -313,7 +313,7 @@ sub convertExpression
     }
     # Check for file system based expression expressions
     foreach (@FILE_BLOCKED_LIST) {
-        if ($expression  =~ /$_/i) {
+        if ($expression  =~ /\b$_/i) {
             print_it($LFILE,"$line\n");
             err_handle $ERR_FILE_BLOCKED_MSG;
             return;
@@ -321,7 +321,7 @@ sub convertExpression
     }
     # Check for blocked expressions
     foreach (@BLOCKED_LIST) {
-        if ($expression  =~ /$_/i) {
+        if ($expression  =~ /\b$_/i) {
             my $err_msg = "Conversion of $_ expression is not supported";
             print_it($LFILE,"$line\n");
             err_handle $err_msg;
@@ -814,12 +814,38 @@ sub identifyExpressions
                 my $OPERATOR=$1;
                 $expr_params=$2;
                 my $ARG = extractArgument();
-                if ($ARG =~ /^\S{3}\, (\d{2}) (\S{3}) (\d{4}) (\d{2}):(\d{2}):(\d{2}) (\S{3})$/) {
+                if ($ARG =~ /^\S{3}\, (\d{1,2}) (\S{3}) (\d{4}) (\d{2}):(\d{2}):(\d{2}) (\S{3})$/) {
+                    # Handling RFC822 format: Tue, 05 Nov 1994 08:12:31 GMT
                     $ARG = "$7 $3 $2 $1 $4h $5m $6s";
                     parseNumericOperator($OPERATOR,$ARG);
                     return;
-                }
-                else {
+                } elsif ($ARG =~ /^\S{3}\, (\d{1,2})-(\S{3})-(\d{4}) (\d{2}):(\d{2}):(\d{2}) (\S{3})$/) {
+                    # Handling cookie format: Tue, 05-Nov-1994 08:12:31 GMT
+                    $ARG = "$7 $3 $2 $1 $4h $5m $6s";
+                    parseNumericOperator($OPERATOR,$ARG);
+                    return;
+                } elsif ($ARG =~ /^\S{3} (\S{3}) (\d{1,2}) (\d{2}):(\d{2}):(\d{2}) (\d{4}) (\S{3})$/) {
+                    # Handling asctime format: Tue Nov 4 08:12:31 1994 GMT
+                    $ARG = "$7 $6 $1 $2 $3h $4m $5s";
+                    parseNumericOperator($OPERATOR,$ARG);
+                    return;
+                } elsif ($ARG =~ /^\S{3} (\S{3}) (\d{1,2}) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/) {
+                    # Handling asctime format: Tue Nov 4 08:12:31 1994 GMT
+                    $ARG = "GMT $6 $1 $2 $3h $4m $5s";
+                    parseNumericOperator($OPERATOR,$ARG);
+                    return;
+                } elsif ($ARG =~ /^\S{5,8}\, (\d{1,2})-(\S{3})-(\d{2}) (\d{2}):(\d{2}):(\d{2}) (\S{3})$/) {
+                    # Handling RFC850 format: Tuesday, 05-Nov-94 08:12:31 GMT
+                    my $year = int($3);
+                    if ($year > 70) {
+                        $year = 1900 + $year;
+                    } else {
+                        $year = 2000 + $year;
+                    }
+                    $ARG = "GMT $year $2 $1 $5h $5m $6s";
+                    parseNumericOperator($OPERATOR,$ARG);
+                    return;
+                } else {
                     err_handle $ERR_OPERATOR_MSG;
                     return;
                 }

--- a/nspepi/nspepi2/nspepi_main.py
+++ b/nspepi/nspepi2/nspepi_main.py
@@ -38,6 +38,7 @@ import convert_cli_commands
 file_log_handler = None
 console_log_handler = None
 debug_log_handler = None
+error_log_handler = None
 
 def create_file_log_handler(file_name, log_level):
     """
@@ -61,12 +62,13 @@ def create_file_log_handler(file_name, log_level):
     file_handler.setFormatter(fh_format)
     return file_handler
 
-def setup_logging(log_file_name, file_log_level, debug_file_name, console_output_needed):
+def setup_logging(log_file_name, file_log_level, error_file_name, debug_file_name, console_output_needed):
     """
     Sets up logging for the program.
 
     Args:
         log_file_name: The name of the log file
+        error_file_name: The name of the error log file
         file_log_level: The level of logs to put in log_file_name file
         debug_file_name: The name of the debug log file
         console_output_needed: True if logs need to be seen on console
@@ -74,17 +76,22 @@ def setup_logging(log_file_name, file_log_level, debug_file_name, console_output
     global file_log_handler
     global console_log_handler
     global debug_log_handler
+    global error_log_handler
     # create logger
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
     # if called multiple times, remove existing handlers
     logger.removeHandler(file_log_handler)
     logger.removeHandler(console_log_handler)
-    logger.removeHandler(debug_log_handler)
+    logger.removeHandler(console_log_handler)
+    logger.removeHandler(error_log_handler)
     # create file handler
     file_log_handler = create_file_log_handler(log_file_name, file_log_level)
     # add the handlers to the logger
     logger.addHandler(file_log_handler)
+    if error_file_name:
+        error_log_handler = create_file_log_handler(error_file_name, logging.ERROR)
+        logger.addHandler(error_log_handler)
     if debug_file_name:
         debug_log_handler = create_file_log_handler(debug_file_name, logging.DEBUG)
         logger.addHandler(debug_log_handler)
@@ -219,6 +226,8 @@ def main():
     arg_parser.add_argument(
         '-V', '--version', action='version',
         version='%(prog)s {}'.format(__version__))
+    arg_parser.add_argument('-E', '--newErrorFileName', action="store_true",
+        help=argparse.SUPPRESS)
     try:
         args = arg_parser.parse_args()
     except IOError as e:
@@ -230,10 +239,11 @@ def main():
         conf_file_path = os.path.dirname(args.infile)
         conf_file_name = os.path.basename(args.infile)
     log_file_name = os.path.join(conf_file_path, 'warn_' + conf_file_name)
+    err_file_name = os.path.join(conf_file_path, 'error_' + conf_file_name) if args.newErrorFileName else None
     debug_file_name = os.path.join(conf_file_path, 'debug_' + conf_file_name) if args.debug else None
     # For -v and -e options, logs will be seen on console and warn file.
     # For other options, logs will only be in warn file and not on console.
-    setup_logging(log_file_name, logging.WARNING, debug_file_name, args.verbose or args.expression is not None)
+    setup_logging(log_file_name, logging.WARNING, err_file_name, debug_file_name, args.verbose or args.expression is not None)
     convert_cli_commands.convert_cli_init()
     # convert classic policy expression if given as an argument
     if args.expression is not None:
@@ -261,6 +271,9 @@ def main():
         with open(args.infile, 'r') as infile:
             with open(new_path, 'w') as outfile:
                 convert_config_file(infile, outfile, args.verbose)
+                if err_file_name:
+                    if os.path.getsize(err_file_name) == 0:
+                        os.remove(err_file_name)
                 if os.path.getsize(log_file_name) == 0:
                     error_warn_msg = ".\nConversion is successful, no error or warning is generated."
                     os.remove(log_file_name)
@@ -271,6 +284,7 @@ def main():
                       + conf_file_name + error_warn_msg) 
                 if args.debug:
                     print("Check debug_" + conf_file_name + " file for debug logs.")
+    print("\nUse nspepi tool available at https://github.com/citrix/ADC-scripts/tree/master/nspepi for the most complete and up-to-date version.")
 
 
 if __name__ == '__main__':

--- a/nspepi/nspepi2/nspepi_parse_tree.py
+++ b/nspepi/nspepi2/nspepi_parse_tree.py
@@ -110,6 +110,7 @@ class CLICommand(CLIParseTreeNode):
                        policy is advanced but need to set upgrade flag after conversion. adv_upgraded should be used
                        in such cases instead of upgraded.
         invalid - Indicates whether the command is invalid in 13.1 release.
+        has_csec_expr - Indicates that command has client security expression
         original_line - the text of the line that was parsed
         lineno - the line number (starting with 1) that the command occurs on
         op - the op-code for the command
@@ -119,6 +120,7 @@ class CLICommand(CLIParseTreeNode):
         self._upgraded = True
         self._adv_upgraded = True
         self._invalid = False
+        self._has_csec_expr = False
         self._original_line = ""
         self._lineno = 0
         self._op = op
@@ -208,6 +210,17 @@ class CLICommand(CLIParseTreeNode):
     @property
     def invalid(self):
         return self._invalid
+
+    def set_has_csec_expr(self):
+        """
+        Flags that this command has
+        Client security expression.
+        """
+        self._has_csec_expr = True
+
+    @property
+    def has_csec_expr(self):
+        return self._has_csec_expr
 
     def add_positional(self, positional_param):
         """ Adds a positional parameter at the end of the parameters.


### PR DESCRIPTION
Handling following issues:
1.  CS policy name changed even when bound to one CS vserver
2. Handling default CMP bindings
3. Throwing error when named expression is configured with client security expression
4. Handling SSL cert related expression